### PR TITLE
downcase require csv

### DIFF
--- a/lib/account.rb
+++ b/lib/account.rb
@@ -1,4 +1,4 @@
-require 'CSV'
+require 'csv'
 
 class Account
   attr_reader :number, :holder

--- a/lib/login_procedure.rb
+++ b/lib/login_procedure.rb
@@ -1,4 +1,4 @@
-require 'CSV'
+require 'csv'
 
 login = false
 

--- a/spec/account_spec.rb
+++ b/spec/account_spec.rb
@@ -1,5 +1,5 @@
 require 'rspec'
-require 'CSV' unless defined?(CSV)
+require 'csv' unless defined?(CSV)
 require_relative '../lib/account'
 
 describe Account do


### PR DESCRIPTION
Correction for error when running Rspec:

```
An error occurred while loading ./spec/account_spec.rb.
Failure/Error: require 'CSV'

LoadError:
  cannot load such file -- CSV
```
Suggest downcasing to "csv" when using require. I believe it is stored as 'csv.rb' in the ruby core class methods, at which point Rspec runs. Check out the In Files section (top left), [in the ruby docs](https://ruby-doc.org/stdlib-2.5.0/libdoc/csv/rdoc/CSV.html), I think that's the naming convention to ape when requiring? 

Use of class method remains caps, so that's all good!